### PR TITLE
Update Lab 6 for changes to Transformers

### DIFF
--- a/MLOps_Professional/lab6/sample/Falcon_HF_Pipelines.py
+++ b/MLOps_Professional/lab6/sample/Falcon_HF_Pipelines.py
@@ -18,7 +18,7 @@ def main(FLAGS):
         model=model,
         tokenizer=tokenizer,
         torch_dtype=torch.bfloat16,
-        trust_remote_code=True,
+        trust_remote_code=False,
         device_map="auto",
     )
 
@@ -34,7 +34,7 @@ def main(FLAGS):
             sequences = generator( 
             f""" {user_input}""",
             max_length=FLAGS.max_length,
-            do_sample=False,
+            do_sample=True,
             top_k=FLAGS.top_k,
             num_return_sequences=1,
             eos_token_id=tokenizer.eos_token_id,)


### PR DESCRIPTION
This PR fixes two issues with Lab 6 ("Hugging Face* LLM Inference"):

* `trust_remote_code` is now set to `False` when building the Transformers pipeline, as this is no longer required by the Transformers library or by the Falcon model.  While `False` is the default setting for the version of Transformers used in this lab (see <https://huggingface.co/docs/transformers/v4.29.1/en/main_classes/pipelines>), owing to the severe security ramification of allowing execution of remote code, I've chosen to be explicit in toggling it off.
* `do_sample` is now set to `True` during inference, as this was causing the `top_k` parameter to be ignored.

Signed-off-by: William Huhn <william.huhn@intel.com>